### PR TITLE
Move Bedroom Jams to past events, set next event as TBA

### DIFF
--- a/HausApetit/index.html
+++ b/HausApetit/index.html
@@ -405,6 +405,8 @@
                 </font>
               </h3>
               <p style="margin: 6px 0 0 0;">
+                <a href="/assets/Haus Apetit/Bedroom-jams.png" target="_blank" rel="noreferrer"><b>Bedroom Jams</b> — Dec 24 & 30, 2025</a>
+                <br>
                 <a href="/assets/Haus Apetit/Poster.png" target="_blank" rel="noreferrer"><b>Sounds N' Visuals</b> — Oct 25, 2025</a>
                 <br>
                 <a href="hummus-jam.html"><b>Hummus & Jam</b> — Oct 18, 2025</a>

--- a/HausApetit/next-event.html
+++ b/HausApetit/next-event.html
@@ -77,21 +77,18 @@
     }
   </style>
   <header class="next-event-header">
-    <h2 class="next-event-title">Next Event: Bedroom Jams</h2>
-    <p class="next-event-when">Wed 24.12 + Tue 30.12 · starting 18:00</p>
+    <h2 class="next-event-title">Next Event</h2>
+    <p class="next-event-when">To be announced — stay tuned!</p>
   </header>
 
   <div class="next-event-body">
-
-	<img src="/assets/Haus Apetit/Bedroom-jams.png" alt="Bedroom Jams Event Poster" class="poster">
-    
 	<div class="next-event-actions">
       <a
         class="next-event-btn"
-        href="https://docs.google.com/forms/d/e/1FAIpQLSdjP9qDqeltOowI-pxJKPGnleieGswJna-igbAhoD0L013FXg/viewform"
+        href="https://t.me/+wWD8DZgSXABiY2E0"
         target="_blank"
         rel="noreferrer"
-      >Sign up (free)</a>
+      >Join Telegram for updates</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Replace the Next Event section content with a "to be announced"
message and Telegram link. Add Bedroom Jams (Dec 24 & 30, 2025)
to the past event pages list with a link to its poster.

https://claude.ai/code/session_01DPU6KNsB98MQUZmQamQAAD