### PR TITLE
Redesign README with comprehensive personal profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,40 @@
-# This is the repository for my personal website.
+## Hi, I'm Ido 👋
 
-- [The project's Notion page](https://ivory-kookaburra-2de.notion.site/Personal-Website-13e460dbb2a180c9909de47ee507db9e?pvs=4)
+Digital nomad from Israel, now based in Berlin 🇩🇪. Over the past 10 years I've learned, mastered, and worked across a few different fields — software engineering, filmmaking, and photography — and I like building things end to end.
 
-## MVP idea
-![](assets/first-mvp.png)
+This repo is the source for my [personal website](https://idonov8.github.io) — vanilla HTML/CSS/JS, no framework, built to be fast and easy to hack on.
+
+### 🚀 What I'm building right now
+
+- **[we4water](https://we4water.com)** — helping a platform for water projects grow: watercrafts, water treatment, and the culture around them
+- **[Berlin Sessions](https://berlin-sessions.com)** — every jam, open mic and live session in Berlin, in one weekly calendar
+- **[Wiki Compare](https://wikicompare.app)** — same article, different truth: how Wikipedia tells the same story in English, Hebrew and Arabic
+
+### 🛠️ Recent work
+
+- **MEET Case Studies** — a gamified website for an educational program's students and staff
+- **LiDAR Visualizer** — a LiDAR measurement visualization tool, freelance project
+- **HospiTrack** — indoor tracking of hospital staff to reduce quarantines during COVID-19
+- I also [broke GitHub Copilot](https://dagshub.com/blog/github-copilot-not-code/) once, and it made the front page of Hacker News
+
+### 🎬 Filmmaking
+
+Short films, music videos, and technical/commercial work — check out the [YouTube channel](https://www.youtube.com/@idonov8), including *Brain Fog*, *So Many People*, and *Walking*.
+
+### 📷 Photography
+
+A rotating gallery lives on [my site](https://idonov8.github.io#photography).
+
+### 📄 More
+
+- [CV / résumé](https://idonov8.github.io/assets/cv-2026.pdf)
+- [Ido's guide to the minimalist iPhone](https://ivory-kookaburra-2de.notion.site/Ido-s-Guide-to-the-minimalist-iPhone-265460dbb2a1809fb5d2d19939118f14?pvs=143)
+
+### 📫 Get in touch
+
+[![Email](https://img.shields.io/badge/Email-idonov8%40gmail.com-D14836?style=flat&logo=gmail&logoColor=white)](mailto:idonov8@gmail.com)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-Ido%20Nov-0A66C2?style=flat&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/ido-nov-83a216149/)
+[![WhatsApp](https://img.shields.io/badge/WhatsApp-Chat-25D366?style=flat&logo=whatsapp&logoColor=white)](https://wa.me/972547898215)
+[![Telegram](https://img.shields.io/badge/Telegram-%40idonov-26A5E4?style=flat&logo=telegram&logoColor=white)](https://t.me/idonov)
+[![YouTube](https://img.shields.io/badge/YouTube-%40idonov8-FF0000?style=flat&logo=youtube&logoColor=white)](https://www.youtube.com/@idonov8)
+[![Website](https://img.shields.io/badge/Website-idonov8.github.io-000000?style=flat&logo=googlechrome&logoColor=white)](https://idonov8.github.io)


### PR DESCRIPTION
## Summary
Completely redesigned the README to serve as a comprehensive personal profile and portfolio, replacing the minimal project-focused version with a detailed introduction and overview of current work, past projects, and contact information.

## Key Changes
- Replaced generic project description with a personal introduction highlighting background as a digital nomad and multi-disciplinary builder
- Added "What I'm building right now" section featuring three active projects (we4water, Berlin Sessions, Wiki Compare)
- Added "Recent work" section documenting past projects and notable achievements
- Included dedicated sections for filmmaking and photography work with links to portfolio
- Added "More" section with links to CV and personal guides
- Replaced plain text contact info with styled badge links for email, LinkedIn, WhatsApp, Telegram, YouTube, and personal website
- Removed outdated MVP mockup and Notion page reference

## Notable Details
- Maintains the vanilla HTML/CSS/JS philosophy of the personal website
- Uses shield.io badges for consistent, professional contact link styling
- Organizes content hierarchically with clear section headers for easy navigation
- Includes direct links to live projects and external portfolios

https://claude.ai/code/session_01AqWiAKPy288QG8ayUGhZja