### PR TITLE
Add CV page with embedded PDF viewer

### DIFF
--- a/cv/index.html
+++ b/cv/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Ido Nov — CV</title>
+	<meta name="description" content="Ido Nov's CV / resume.">
+	<link rel="canonical" href="https://idonov.com/cv">
+	<link rel="icon" href="/favicon.ico">
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link
+		href="https://fonts.googleapis.com/css2?family=Instrument+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Instrument+Serif:ital,wght@0,400;0,500;0,600;1,400&display=swap"
+		rel="stylesheet">
+	<style>
+		:root {
+			--color-bg: #101014;
+			--color-surface: #17171d;
+			--color-text: #f2f2f2;
+			--color-muted: #9a9aa4;
+			--color-primary: #49f87a;
+			--color-border: #2a2a33;
+		}
+
+		* {
+			box-sizing: border-box;
+		}
+
+		html, body {
+			margin: 0;
+			padding: 0;
+			height: 100%;
+		}
+
+		body {
+			background-color: var(--color-bg);
+			color: var(--color-text);
+			font-family: "Instrument Sans", system-ui, sans-serif;
+			display: flex;
+			flex-direction: column;
+			min-height: 100vh;
+		}
+
+		header {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 16px;
+			padding: 20px clamp(16px, 5vw, 48px);
+			border-bottom: 1px solid var(--color-border);
+			flex-wrap: wrap;
+		}
+
+		.back-link {
+			color: var(--color-muted);
+			text-decoration: none;
+			font-size: 0.95rem;
+			transition: color 150ms ease;
+		}
+
+		.back-link:hover {
+			color: var(--color-primary);
+		}
+
+		h1 {
+			font-family: "Instrument Serif", serif;
+			font-weight: 400;
+			font-size: 1.6rem;
+			margin: 0;
+		}
+
+		.download-btn {
+			display: inline-flex;
+			align-items: center;
+			gap: 8px;
+			padding: 8px 16px;
+			border-radius: 6px;
+			background-color: var(--color-primary);
+			color: #0b0b0d;
+			font-weight: 600;
+			text-decoration: none;
+			font-size: 0.9rem;
+			transition: transform 150ms ease, box-shadow 150ms ease;
+		}
+
+		.download-btn:hover {
+			transform: translateY(-1px);
+			box-shadow: 0 4px 12px rgba(73, 248, 122, 0.25);
+		}
+
+		main {
+			flex: 1;
+			display: flex;
+			justify-content: center;
+			padding: clamp(16px, 3vw, 40px);
+		}
+
+		.pdf-frame {
+			width: 100%;
+			max-width: 900px;
+			background-color: var(--color-surface);
+			border: 1px solid var(--color-border);
+			border-radius: 10px;
+			overflow: hidden;
+			box-shadow: 0 8px 30px rgba(0, 0, 0, 0.4);
+		}
+
+		.pdf-frame object,
+		.pdf-frame iframe {
+			display: block;
+			width: 100%;
+			height: 85vh;
+			border: none;
+		}
+
+		.fallback {
+			padding: 48px 24px;
+			text-align: center;
+			color: var(--color-muted);
+		}
+
+		.fallback a {
+			color: var(--color-primary);
+		}
+	</style>
+</head>
+<body>
+	<header>
+		<a class="back-link" href="/">← idonov.com</a>
+		<h1>Ido Nov — CV</h1>
+		<a class="download-btn" href="/assets/cv-2026.pdf" download>Download PDF</a>
+	</header>
+	<main>
+		<div class="pdf-frame">
+			<object data="/assets/cv-2026.pdf" type="application/pdf">
+				<p class="fallback">
+					Your browser can't preview PDFs inline.<br>
+					<a href="/assets/cv-2026.pdf">Open the CV directly</a>.
+				</p>
+			</object>
+		</div>
+	</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Added a new CV page at `/cv` that displays an embedded PDF viewer for the CV document with a clean, modern design matching the site's aesthetic.

## Key Changes
- Created `cv/index.html` with a dedicated CV page featuring:
  - Header with back navigation, title, and PDF download button
  - Embedded PDF viewer using the `<object>` element for inline preview
  - Fallback link for browsers that don't support inline PDF rendering
  - Responsive design with dark theme matching the site's color scheme
  - Custom styling using CSS variables for consistent theming
  - Google Fonts integration (Instrument Sans and Instrument Serif)

## Implementation Details
- The page uses semantic HTML with proper meta tags (charset, viewport, description, canonical URL)
- Responsive layout with `clamp()` for fluid spacing that adapts to different screen sizes
- PDF viewer height set to 85vh to accommodate the header while maximizing content visibility
- Download button includes hover effects (transform and shadow) for better UX
- Graceful degradation with fallback text and direct link for unsupported browsers
- Dark color palette with green accent color (#49f87a) for primary actions

https://claude.ai/code/session_01XvxBThAmYxN59DzEJi8cEE